### PR TITLE
Remove checks for GAP 4.5.0, require GAP 4.9

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -114,12 +114,12 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP := ">=4.8",
+  GAP := " >= 4.9.0",
   # Needed packages:
   # GapDoc provides the function ParseTreeXMLString
   # IO is needed to generate random string from really random source 
-  NeededOtherPackages := [ [ "GapDoc", ">= 1.5" ], 
-                           [ "IO", ">= 4.4"] ],
+  NeededOtherPackages := [ [ "GAPDoc", ">= 1.6.0" ],
+                           [ "IO", ">= 4.5.1" ] ],  
   ExternalConditions := [ ]
 ),
 

--- a/gap/gap.g
+++ b/gap/gap.g
@@ -1108,17 +1108,6 @@ semigroup2 := rec(
 	right_multiplication := fail
 ),
 
-semigroup3 := rec(
-	automorphism_group := AutomorphismGroup, # requires MONOID package and 
-	                                         # GRAPE, duplicated in semigroup4 CD
-	cyclic_semigroup := fail, 
-	direct_power := fail, 
-	direct_product := fail, 
-	free_semigroup := fail, 
-	left_regular_representation := fail, 
-	maps_semigroup := fail
-),
-
 semigroup4 := rec(
 	automorphism_group := fail,
 	homomorphism_by_generators := fail
@@ -1187,20 +1176,6 @@ setname2 := rec(
 )
 
 ));
- 
-if not CompareVersionNumbers( GAPInfo.Version, "4.5.0") then
-# this requires MONOID so will not work in GAP 4.5
-  OMsymRecord.semigroup4 := rec(
-	automorphism_group := AutomorphismGroup, # requires MONOID package and GRAPE, 
-	                                         # duplicated in semigroup3 CD
-	homomorphism_by_generators :=            # requires MONOID
-        function(x)
-        local g;
-        # we use NC method trusting that the client send valid input 
-        # (this must be the case for the GAP client)
-        return SemigroupHomomorphismByImagesOfGensNC( x[1], x[2], List( x[3], g -> g[2] ) );
-        end);
-fi;
 
 ######################################################################
 ##

--- a/gap/omput.gi
+++ b/gap/omput.gi
@@ -523,32 +523,6 @@ function(writer, x)
     OMPutEndOMA(writer);
 end); 
 
-
-###########################################################################
-##
-#M  OMPut( <OMWriter>, <semigrouphom> )  
-##
-##  this requires MONOID so will not work in GAP 4.5
-if not CompareVersionNumbers( GAPInfo.Version, "4.5.0") then
-InstallMethod(OMPut, "for a semigroup homomorphism given by images of generators", true,
-[IsOpenMathWriter, IsSemigroupHomomorphism and IsSemigroupHomomorphismByImagesOfGensRep],0,
-function(writer, x)
-    local g;
-	OMPutOMA(writer);
-	OMPutSymbol( writer, "semigroup4", "homomorphism_by_generators" );
-	OMPut(writer, Source(x) );
-	OMPut(writer, Range(x) ); 
-	if IsMonoid( Source(x) ) then
-        OMPut(writer, List( GeneratorsOfMonoid( Source( x ) ), g -> [ g, g^x ] ) );
-    elif IsSemigroup( Source(x) ) then
-        OMPut(writer, List( GeneratorsOfSemigroup( Source( x ) ), g -> [ g, g^x ] ) );
-    else
-        Error( "OMPut for a semigroup homomorphism given by images of generators: can not output ", x );  
-    fi;        
-    OMPutEndOMA(writer);
-end);
-fi;
-
 ###########################################################################
 #
 # OMPut for a univariate polynomial (polyu.poly_u_rep)

--- a/gap/xmltree.g
+++ b/gap/xmltree.g
@@ -36,11 +36,7 @@ BindGlobal( "OMObjects",
         if not IsBound( node.attributes.dec )  then
             Error( "hexadecimal encoding of floats is not supported" );
         fi;
-        if CompareVersionNumbers( GAPInfo.Version, "4.5.0") then
-        	return Float( node.attributes.dec );
-        else
-        	return Float( node.attributes.dec );
-        fi;
+        return Float( node.attributes.dec );
     end,
 
 
@@ -198,8 +194,6 @@ OMSTR := function ( node )
 
 MakeReadWriteGlobal("OMObjects"); 
 
-if CompareVersionNumbers( GAPInfo.Version, "4.5.0") then 
-
 OMObjects.OMF := 
     function ( node )
         if not IsBound( node.attributes.dec )  then
@@ -207,18 +201,6 @@ OMObjects.OMF :=
         fi;
       	return Float( node.attributes.dec );
     end;
-
-else
-
-OMObjects.OMF := 
-    function ( node )
-        if not IsBound( node.attributes.dec )  then
-            Error( "hexadecimal encoding of floats is not supported" );
-        fi;
-       	return Float( node.attributes.dec );
-    end;
-
-fi;
 
 #############################################################################
 #E


### PR DESCRIPTION
Semigroups code that was under a CompareVersionNumbers guard does not work
anymore (not even with the Semigroups package), hence remove it.