### PR TITLE
Refactor function OMGetObject

### DIFF
--- a/gap/omget.gd
+++ b/gap/omget.gd
@@ -65,6 +65,7 @@
 ##  </Description>
 ##  </ManSection>
 ##  <#/GAPDoc>
+DeclareGlobalFunction("OMGetTree");
 DeclareGlobalFunction("OMGetObject");
 
 

--- a/gap/xmltree.gi
+++ b/gap/xmltree.gi
@@ -7,12 +7,13 @@
 #Y    School Math and Comp. Sci., University of St.  Andrews, Scotland
 #Y    Copyright (C) 2004, 2005, 2006 Marco Costantini
 ##
-##  The main function in this file converts the OpenMath XML into a tree
-##  (using the function ParseTreeXMLString from package GapDoc) and
-##  parses it.
+##  The main function in this file converts an XML document that is encoded
+##  as a GAP record (as output by ParseTreeXMLString) into a GAP Object.
 ##
 
-
+## TODO: Move this function to xmltree.g?
+## One must not reset OMTempVars in this function, because it is called
+## from code in xmltree.g while parsing objects.
 InstallGlobalFunction( OMParseXmlObj, function ( node )
     local obj;
 
@@ -20,9 +21,8 @@ InstallGlobalFunction( OMParseXmlObj, function ( node )
         Error( "unknown OpenMath object ", node.name );
     fi;
 
-    if IsBound( node.content ) and 
-       IsList( node.content ) and 
-        not (node.name = "OMSTR" or node.name = "OMI" or node.name = "OMB")  then
+    if IsBound( node.content ) and IsList( node.content ) and
+       not (node.name = "OMSTR" or node.name = "OMI" or node.name = "OMB")  then
         node.content := Filtered( node.content, OMIsNotDummyLeaf );
     fi;
     obj := OMObjects.(node.name)( node );
@@ -33,29 +33,6 @@ InstallGlobalFunction( OMParseXmlObj, function ( node )
 
     return obj;
 end );
-
-
-
-
-InstallGlobalFunction( OMgetObjectXMLTree, function ( string )
-    local  node;
-
-    # TODO: this maybe be reset in the middle of the session
-    # making references invalid. We need either to keep this
-    # for the whole session or to create another record to 
-    # store such objects
-    
-    OMTempVars.OMBIND := rec(  );
-    OMTempVars.OMREF := rec(  );
-
-    node := ParseTreeXMLString( string ).content[1];
-    # DisplayXMLStructure( node );
-    node.content := Filtered( node.content, OMIsNotDummyLeaf );
-
-    return OMParseXmlObj( node.content[1] );
-
-end );
-
 
 #############################################################################
 #E

--- a/tst/omget.tst
+++ b/tst/omget.tst
@@ -1,0 +1,47 @@
+# Test OMGet (doesn't test that much yet other than that it runs.
+gap> OMGetTree("abc");
+Error, <stream> has to be an input stream
+gap> stream := OutputTextString("", true);;
+gap> OMGetTree(stream);
+Error, <stream> has to be an input stream
+gap> stream := InputTextString("abc");; ReadAll(stream);;
+gap> OMGetTree(stream);
+Error, <stream> is in state end-of-stream
+gap> obj := """
+> <OMOBJ>
+> </OMOBJ>
+> """;;
+gap> stream := InputTextString(obj);;
+gap> tree := OMGetTree(stream);;
+gap> obj := """
+> <?scscp start ?>
+> <OMOBJ xmlns="http://www.openmath.org/OpenMath" version="2.0">
+> 	<OMATTR>
+> 		<OMATP>
+> 			<OMS cd="scscp1" name="call_id"/>
+> 			<OMSTR>user007</OMSTR>
+> 			<OMS cd="scscp1" name="option_runtime"/>
+> 			<OMI>1000</OMI>
+> 			<OMS cd="scscp1" name="option_min_memory"/>
+> 			<OMI>1024</OMI>
+> 			<OMS cd="scscp1" name="option_max_memory"/>
+> 			<OMI>2048</OMI>
+> 			<OMS cd="scscp1" name="option_debuglevel"/>
+> 			<OMI>1</OMI>
+> 			<OMS cd="scscp1" name="option_return_object"/>
+> 			<OMSTR></OMSTR>
+> 		</OMATP>
+> 		<OMA>
+> 			<OMS cd="scscp1" name="procedure_call"/>
+> 			<OMA>
+> 				<OMS cd="scscp_transient_1" name="WS_Factorial"/>
+> 				<OMI>5</OMI>
+> 			</OMA>
+> 		</OMA>
+> 	</OMATTR>
+> </OMOBJ>
+> <?scscp end ?>
+> """;;
+gap> stream := InputTextString(obj);; OMGetTree(stream);;
+
+#


### PR DESCRIPTION
For this first pull out the heavy lifting into the function
OMGetTree that returns a record representation of the OpenMath
object, and use this function in OMGetObject to return a GAP
object.