### PR TITLE
Rename gap/test.g* -> gap/testing.g*

### DIFF
--- a/gap/testing.g
+++ b/gap/testing.g
@@ -1,6 +1,6 @@
 #######################################################################
 ##
-#W  test.g             GAP OpenMath Package              Andrew Solomon
+#W  testing.g          GAP OpenMath Package              Andrew Solomon
 #W                                                     Marco Costantini
 ##
 #Y  Copyright (C) 1999, 2000, 2001, 2006

--- a/gap/testing.gd
+++ b/gap/testing.gd
@@ -1,6 +1,6 @@
 #######################################################################
 ##
-#W  test.gd          GAP OpenMath Package                Andrew Solomon
+#W  testing.         GAP OpenMath Package                Andrew Solomon
 #W                                                     Marco Costantini
 ##
 #Y    Copyright (C) 1999, 2000, 2001, 2006

--- a/init.g
+++ b/init.g
@@ -24,7 +24,7 @@ ReadPackage("openmath", "/gap/parse.gd");
 ReadPackage("openmath", "/gap/xmltree.gd");
 ReadPackage("openmath", "/gap/omget.gd");
 ReadPackage("openmath", "/gap/omput.gd");
-ReadPackage("openmath", "/gap/test.gd");
+ReadPackage("openmath", "/gap/testing.gd");
 
 #############################################################################
 ##
@@ -131,11 +131,11 @@ ReadPackage("openmath", "/hasse/hasse.g");
 
 
 #############################################################################
-## Module 3: test
+## Module 3: testing
 ## Provides the function OMTest for testing OMGetObject.OMPutObject = id
 ## requires OMGetObject and OMPutObject
 
-ReadPackage("openmath", "/gap/test.g");
+ReadPackage("openmath", "/gap/testing.g");
 
 
 #############################################################################

--- a/makedoc.g
+++ b/makedoc.g
@@ -41,7 +41,7 @@ OPENMATHMANUALFILES:=[
 "../PackageInfo.g", 
 "../gap/omget.gd",
 "../gap/omput.gd",
-"../gap/test.gd" 
+"../gap/testing.gd" 
 ];
 
 ###########################################################################

--- a/tst/openmath02.tst
+++ b/tst/openmath02.tst
@@ -162,13 +162,13 @@ gap> OMPrint(s);
 </OMOBJ>
 
 
-# [ "doc/../gap/test.gd", 28, 33 ]
+# [ "doc/../gap/testing.gd", 28, 33 ]
 
 gap> OMTestXML([[1..10],[1/2,2+E(4)],ZmodnZObj(2,6),(1,2),true,"string"]);     
 true
 
 
-# [ "doc/../gap/test.gd", 58, 63 ]
+# [ "doc/../gap/testing.gd", 58, 63 ]
 
 gap> OMTestBinary([[1..10],[1/2,2+E(4)],ZmodnZObj(2,6),(1,2),true,"string"]);     
 true


### PR DESCRIPTION
I have just renamed the file, and this fixed CodeCov counting, which has been reporting that test.g has 1,8K lines (and it actually has only two small functions). I suggest to merge this, as the renaming is meaningful anyway.
 